### PR TITLE
docs: 修正根 README 文件结构并补充文档入口说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,23 +63,29 @@ export SXSC_TUSHARE_TOKEN="你的token"
 ## 文件结构
 
 ```
-shanxi-securities-tushare/
-├── SKILL.md                          # 技能主文件（320 行，精简版）
-├── README.md                         # 本文件
-├── scripts/
-│   ├── stock_data_demo.py            # 股票数据示例脚本
-│   └── fund_data_demo.py             # 基金数据示例脚本
-└── references/
-    ├── API接口对应表.md              # 101 个 API ↔ 文档映射（必查）
-    ├── 调取数据.md                   # 环境配置与调用说明
-    ├── intent_taxonomy.md            # 意图分类详解（10 大场景）
-    ├── workflow_templates.md         # 工作流模板（5 种路径）
-    ├── examples.md                   # 完整代码示例集合
-    ├── 基础信息.md                   # stock_basic 接口文档
-    ├── A股日线行情.md                # daily 接口文档
-    ├── ... (共 101 个 API 接口文档)
-    └── (其他参考文档)
+.
+├── README.md                                  # 根文档（总入口）
+├── LICENSE
+└── shanxi-securities-tushare/
+    ├── SKILL.md                               # 执行规范入口
+    ├── scripts/
+    │   ├── stock_data_demo.py                 # 股票数据示例脚本
+    │   └── fund_data_demo.py                  # 基金数据示例脚本
+    └── references/
+        ├── API接口对应表.md                   # 101 个 API ↔ 文档映射（必查）
+        ├── 调取数据.md                        # 环境配置与调用说明
+        ├── intent_taxonomy.md                 # 意图分类详解（10 大场景）
+        ├── workflow_templates.md              # 工作流模板（5 种路径）
+        ├── examples.md                        # 完整代码示例集合
+        ├── 基础信息.md                        # stock_basic 接口文档
+        ├── A股日线行情.md                     # daily 接口文档
+        ├── ...（其余接口与专题文档见 references/）
 ```
+
+## 文档入口说明
+
+- 根目录 `README.md`：项目总入口（安装、触发条件、整体结构说明）
+- `shanxi-securities-tushare/SKILL.md`：执行规范入口（调用原则、流程与约束）
 
 ## 核心原则：先查表，再调用
 


### PR DESCRIPTION
### Motivation

- 对齐根文档与仓库实际文件结构，移除 README 中列出的不存在条目以避免误导。 
- 明确文档入口，指出项目总入口与技能执行规范入口的职责分工以便使用者快速定位。 

### Description

- 将 `README.md` 中的“文件结构”代码块替换为与仓库实际文件列表一致的树状视图（包含根 `README.md`、`LICENSE` 以及 `shanxi-securities-tushare/` 子目录）。
- 删除了错误的 `shanxi-securities-tushare/README.md` 条目并改为列出真实存在的 `shanxi-securities-tushare/SKILL.md`、`scripts/` 和 `references/` 内容摘要。
- 新增 “文档入口说明” 小节，明确 `README.md` 为项目总入口，`shanxi-securities-tushare/SKILL.md` 为执行规范入口。 

### Testing

- 已使用 `sed -n '1,260p' README.md` 验证并查看文件头部内容变更，命令执行成功。 
- 已使用 `find . -maxdepth 3 -type f | sort` 与 `find . -maxdepth 2 -type f | sort` 校核仓库实际文件清单并比对文档描述，命令执行成功。 
- 已通过 `git commit` 提交更改并用 `nl -ba README.md | sed -n '60,120p'` 验证插入的代码块与“文档入口说明”段落已生效，提交与验证均成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad443cd30832a939245710094c323)